### PR TITLE
Fix: Configure test environment and improve encoding handling

### DIFF
--- a/test.py
+++ b/test.py
@@ -21,7 +21,7 @@ def main():
 
     # Parse the LBL file
     print(f"Parsing {SAMPLE_LBL_FILE}...")
-    with open(SAMPLE_LBL_FILE, 'r') as infile:
+    with open(SAMPLE_LBL_FILE, 'r', encoding='latin-1') as infile:
         label_data = label_parser.parse(infile)
 
     if not label_data:

--- a/test_odl.py
+++ b/test_odl.py
@@ -18,7 +18,7 @@ class TestODLParser(unittest.TestCase):
     def setUpClass(cls):
         """Parse the sample LBL file once for all tests in this class."""
         cls.label_parser = odl.ODL()
-        with open(SAMPLE_LBL_FILE, 'r') as f:
+        with open(SAMPLE_LBL_FILE, 'r', encoding='latin-1') as f:
             cls.parsed_label_data = cls.label_parser.parse(f)
 
         # cls.img_label_parser = odl.ODL()
@@ -141,7 +141,7 @@ class TestODLParser(unittest.TestCase):
                         f"Sample IMG file with embedded label missing: {SAMPLE_IMG_WITH_EMBEDDED_LABEL}")
 
         parser = odl.ODL()
-        with open(SAMPLE_IMG_WITH_EMBEDDED_LABEL, 'r') as f_img:
+        with open(SAMPLE_IMG_WITH_EMBEDDED_LABEL, 'r', encoding='latin-1') as f_img:
             # The ODL parser's try-except for UnicodeDecodeError should handle the binary part
             parsed_data = parser.parse(f_img)
 


### PR DESCRIPTION
- Download sample data required for tests.
- Install numpy, a missing dependency.
- Specify 'latin-1' encoding when opening label files in tests to improve robustness with PDS3 standards.

The UnicodeDecodeError warning observed during tests when parsing IMG files with embedded labels is expected behaviour, as the parser correctly identifies the transition from text to binary data.