### PR TITLE
Fix: Download sample data in GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,6 +49,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Download sample data
+      run: |
+        bash samples/get_samples.sh
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
- Added a step to the GitHub Actions workflow to run `bash samples/get_samples.sh` before executing tests. This ensures that the necessary sample files are available in the CI environment, resolving test failures due to FileNotFoundError.
- Previous commits in this branch also addressed test environment setup (numpy installation) and robust encoding handling (`latin-1`) for test files.